### PR TITLE
Gracefully handle missing UI nodes in Growth Plan widget

### DIFF
--- a/vivo-promoter-pro-en-v19.html
+++ b/vivo-promoter-pro-en-v19.html
@@ -288,7 +288,8 @@ th{font-size:12px;color:#556}tfoot td{font-weight:bold}.muted{color:#66708a;font
       lastPlan = plan.filter(p=>p.add>0);
       UI.apply.style.display='inline-block';
     }catch(e){
-      UI.msg.textContent='—'; UI.apply.style.display='none';
+      if (UI.msg) UI.msg.textContent='—';
+      if (UI.apply) UI.apply.style.display='none';
     }
   }
 


### PR DESCRIPTION
## Summary
- Avoid runtime errors when Growth Plan elements are missing by checking UI nodes before updating them

## Testing
- `node -e "console.log('No tests specified')"`

------
https://chatgpt.com/codex/tasks/task_e_68b01300338c8327b098f25da043da13